### PR TITLE
GitHub Actions for PR and Testing | Dockerfile additions for local development

### DIFF
--- a/.github/actions/common/setup-build-environment/action.yml
+++ b/.github/actions/common/setup-build-environment/action.yml
@@ -1,0 +1,37 @@
+name: Setup Build Environment
+description: Setup Python/Brownie/NodeJS Development Environment for PR/Build Tasks
+inputs:
+  python_version:
+    description: Version of Python to Install
+    required: true
+  poetry_version:
+    description: Version of Poetry to Install
+    required: false
+    default: 1.1.12
+  openzeppelin_version:
+    description: Version of OpenZeppelin Contracts to Install
+    default: 4.3.0
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ inputs.python_version }}
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: |
+        pip install poetry==${{ inputs.poetry_version }}
+      shell: bash
+    - run: |
+        npm install -g ganache-cli
+      shell: bash
+    - run: |
+        poetry update
+      shell: bash
+    - run: |
+        poetry run brownie pm install OpenZeppelin/openzeppelin-contracts@${{ inputs.openzeppelin_version }}
+      shell: bash
+    - run: |
+        poetry run brownie compile --all
+      shell: bash

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -1,0 +1,26 @@
+name: Pull Request Builder
+# TODO
+# * change `1.1.11` to input variable
+# * change open zepplin and brownie packages to variable
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ['3.9.6']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/common/setup-build-environment
+      with:
+        python_version: ${{ matrix.python_version }}
+    - run: |
+        poetry run brownie test
+      shell: bash
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish Release (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python_version: ['3.9.6']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ./.github/actions/common/setup-build-environment
+      with:
+        python_version: ${{ matrix.python_version }}
+    - name: Get Project Version
+      id: version
+      run: echo ::set-output name=version::$(poetry version --short)
+      shell: bash
+    - name: Create Project Release
+      id: project-release
+      uses: actions/create-release@latest
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: v${{ steps.version.outputs.version }}
+        release_name: v${{ steps.version.outputs.version }}
+        draft: false
+        prerelease: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM python:3.9.6-slim-buster as requirements
+
+RUN mkdir /registry && \
+    apt-get update && \
+    apt-get install -y linux-headers-amd64 gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install poetry
+
+COPY / /registry
+WORKDIR /registry
+
+RUN poetry export -f requirements.txt --dev --without-hashes -o /tmp/requirements.txt
+
+FROM python:3.9.6-slim-buster
+
+RUN mkdir /registry \
+    && apt-get update \
+    && apt-get install -y curl linux-headers-amd64 gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY / /registry
+WORKDIR /registry
+
+COPY --from=requirements /tmp/requirements.txt .
+
+RUN pip install -r requirements.txt \
+    && brownie pm install OpenZeppelin/openzeppelin-contracts@4.3.0
+
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g ganache-cli
+
+RUN brownie compile --all
+
+CMD ["/usr/local/bin/brownie","test"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+IMAGE = "renft/registry"
+VERSION ?= $(shell cat pyproject.toml| grep version| awk -F'"' {'print $$2'})
+
+docker:
+	docker build -t ${IMAGE}:v$(VERSION) .
+
+shell:
+	docker build -t ${IMAGE}:v${VERSION}-shell -f poetry.Dockerfile .
+	docker run -it --rm -v $(PWD):/registry ${IMAGE}:v${VERSION}-shell
+
+clean-shell:
+	docker rmi ${IMAGE}:v${VERSION}-shell

--- a/dockerfs/shell-entrypoint.sh
+++ b/dockerfs/shell-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+poetry update
+poetry run brownie pm install OpenZeppelin/openzeppelin-contracts@4.3.0
+
+cd /registry/contracts
+poetry run brownie compile --all
+
+cd /registry
+
+poetry shell

--- a/poetry.Dockerfile
+++ b/poetry.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.9.6-slim-buster
+
+RUN mkdir /registry && \
+    apt-get update && \
+    apt-get install -y curl linux-headers-amd64 gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install poetry
+
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g ganache-cli
+
+WORKDIR /registry
+COPY /dockerfs/shell-entrypoint.sh /entrypoint.sh
+
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
GitHub action files included enable two specific actions:

1. PR Checks: any PR created by an already contributed dev, and ones that are 'approved' from devs that have not been contributed, must first run all available `brownie` tests before being able to be merged.  This of course, can be bypassed by administrative powers.
2. Release: creates a generic `release` point in GitHub (w/ tag too).  Version is based on Poetry version.  This is if you ever want to have a 'snapshot' of your code commits to specify as a 'working version'.

Outside of the GitHub actions are Dockerfile's and a `Makefile` to assist in local development or CICD purposes eventually.  These Dockerfile's contain instructions on building an ubuntu variant of a workstation to test the brownie code and should contain all necessary tools to test the code after anyone builds upon it.  Furthermore it is a static version - ie: your devs should have consistent 'testing' across the board as its using python 3.9.6 (3.9.7 won't work yet with brownie) and a specific version of poetry, and OpenZeppelin.

If this isn't necessary at this time I completely understand - was just looking to help!